### PR TITLE
Setup a watch and pipe pod metadata to the namespace cache

### DIFF
--- a/src/Kubernetes.Controller/Caching/ICache.cs
+++ b/src/Kubernetes.Controller/Caching/ICache.cs
@@ -18,6 +18,7 @@ public interface ICache
     void Update(WatchEventType eventType, V1IngressClass ingressClass);
     bool Update(WatchEventType eventType, V1Ingress ingress);
     ImmutableList<string> Update(WatchEventType eventType, V1Service service);
+    ImmutableList<string> Update(WatchEventType eventType, V1Pod service);
     ImmutableList<string> Update(WatchEventType eventType, V1Endpoints endpoints);
     void Update(WatchEventType eventType, V1Secret secret);
     bool TryGetReconcileData(NamespacedName key, out ReconcileData data);

--- a/src/Kubernetes.Controller/Caching/IngressCache.cs
+++ b/src/Kubernetes.Controller/Caching/IngressCache.cs
@@ -94,6 +94,16 @@ public class IngressCache : ICache
         return Namespace(service.Namespace()).Update(eventType, service);
     }
 
+    public ImmutableList<string> Update(WatchEventType eventType, V1Pod pod)
+    {
+        if (pod is null)
+        {
+            throw new ArgumentNullException(nameof(pod));
+        }
+
+        return Namespace(pod.Namespace()).Update(eventType, pod);
+    }
+
     public ImmutableList<string> Update(WatchEventType eventType, V1Endpoints endpoints)
     {
         return Namespace(endpoints.Namespace()).Update(eventType, endpoints);

--- a/src/Kubernetes.Controller/Caching/PodData.cs
+++ b/src/Kubernetes.Controller/Caching/PodData.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using k8s.Models;
+using System;
+
+namespace Yarp.Kubernetes.Controller.Caching;
+
+/// <summary>
+/// Holds data needed from a <see cref="V1Service"/> resource.
+/// </summary>
+#pragma warning disable CA1815 // Override equals and operator equals on value types
+public struct PodData
+#pragma warning restore CA1815 // Override equals and operator equals on value types
+{
+    public PodData(V1Pod service)
+    {
+        if (service is null)
+        {
+            throw new ArgumentNullException(nameof(service));
+        }
+
+        Spec = service.Spec;
+        Status = service.Status;
+        Metadata = service.Metadata;
+    }
+
+    public V1PodSpec Spec { get; set; }
+    public V1PodStatus Status { get; set; }
+    public V1ObjectMeta Metadata { get; set; }
+}

--- a/src/Kubernetes.Controller/Client/V1PodResourceInformer.cs
+++ b/src/Kubernetes.Controller/Client/V1PodResourceInformer.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using k8s;
+using k8s.Autorest;
+using k8s.Models;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Yarp.Kubernetes.Controller.Client;
+
+internal class V1PodResourceInformer : ResourceInformer<V1Pod, V1PodList>
+{
+    public V1PodResourceInformer(
+        IKubernetes client,
+        ResourceSelector<V1Pod> selector,
+        IHostApplicationLifetime hostApplicationLifetime,
+        ILogger<V1PodResourceInformer> logger)
+        : base(client, selector, hostApplicationLifetime, logger)
+    {
+    }
+
+    protected override Task<HttpOperationResponse<V1PodList>> RetrieveResourceListAsync(bool? watch = null, string resourceVersion = null, ResourceSelector<V1Pod> resourceSelector = null, CancellationToken cancellationToken = default)
+    {
+        return Client.CoreV1.ListPodForAllNamespacesWithHttpMessagesAsync(watch: watch, resourceVersion: resourceVersion, fieldSelector: resourceSelector?.FieldSelector, cancellationToken: cancellationToken);
+    }
+}

--- a/src/Kubernetes.Controller/Converters/YarpIngressContext.cs
+++ b/src/Kubernetes.Controller/Converters/YarpIngressContext.cs
@@ -8,15 +8,17 @@ namespace Yarp.Kubernetes.Controller.Converters;
 
 internal sealed class YarpIngressContext
 {
-    public YarpIngressContext(IngressData ingress, List<ServiceData> services, List<Endpoints> endpoints)
+    public YarpIngressContext(IngressData ingress, List<ServiceData> services, List<Endpoints> endpoints, List<PodData> podsList)
     {
         Ingress = ingress;
         Services = services;
         Endpoints = endpoints;
+        PodsList = podsList;
     }
 
     public YarpIngressOptions Options { get; set; } = new YarpIngressOptions();
     public IngressData Ingress { get; }
     public List<ServiceData> Services { get; }
     public List<Endpoints> Endpoints { get; }
+    public List<PodData> PodsList { get; }
 }

--- a/src/Kubernetes.Controller/Converters/YarpParser.cs
+++ b/src/Kubernetes.Controller/Converters/YarpParser.cs
@@ -26,7 +26,7 @@ internal static class YarpParser
             defaultSubsets = ingressContext.Endpoints.SingleOrDefault(x => x.Name == defaultService?.Name).Subsets;
         }
 
-        // cluster can contain multiple replicas for each destination, need to know the lookup base don endpoints
+        // cluster can contain multiple replicas for each destination, need to know the lookup based on endpoints
         var options = HandleAnnotations(ingressContext, ingressContext.Ingress.Metadata);
 
         foreach (var rule in spec?.Rules ?? Enumerable.Empty<V1IngressRule>())

--- a/src/Kubernetes.Controller/Management/KubernetesReverseProxyServiceCollectionExtensions.cs
+++ b/src/Kubernetes.Controller/Management/KubernetesReverseProxyServiceCollectionExtensions.cs
@@ -85,6 +85,7 @@ public static class KubernetesReverseProxyServiceCollectionExtensions
         // Register the necessary Kubernetes resource informers
         services.RegisterResourceInformer<V1Ingress, V1IngressResourceInformer>();
         services.RegisterResourceInformer<V1Service, V1ServiceResourceInformer>();
+        services.RegisterResourceInformer<V1Pod, V1PodResourceInformer>();
         services.RegisterResourceInformer<V1Endpoints, V1EndpointsResourceInformer>();
         services.RegisterResourceInformer<V1IngressClass, V1IngressClassResourceInformer>();
 

--- a/src/Kubernetes.Controller/Services/ReconcileData.cs
+++ b/src/Kubernetes.Controller/Services/ReconcileData.cs
@@ -14,7 +14,7 @@ namespace Yarp.Kubernetes.Controller.Services;
 public struct ReconcileData
 #pragma warning restore CA1815 // Override equals and operator equals on value types
 {
-    public ReconcileData(IngressData ingress, List<ServiceData> services, List<Endpoints> endpoints)
+    public ReconcileData(IngressData ingress, List<ServiceData> services, List<Endpoints> endpoints, List<PodData> pods)
     {
         Ingress = ingress;
         ServiceList = services;
@@ -24,4 +24,5 @@ public struct ReconcileData
     public IngressData Ingress { get; }
     public List<ServiceData> ServiceList { get; }
     public List<Endpoints> EndpointsList { get; }
+    public List<PodData> PodsList { get; }
 }

--- a/src/Kubernetes.Controller/Services/Reconciler.cs
+++ b/src/Kubernetes.Controller/Services/Reconciler.cs
@@ -47,7 +47,7 @@ public partial class Reconciler : IReconciler
                 {
                     if (_cache.TryGetReconcileData(new NamespacedName(ingress.Metadata.NamespaceProperty, ingress.Metadata.Name), out var data))
                     {
-                        var ingressContext = new YarpIngressContext(ingress, data.ServiceList, data.EndpointsList);
+                        var ingressContext = new YarpIngressContext(ingress, data.ServiceList, data.EndpointsList, data.PodsList);
                         YarpParser.ConvertFromKubernetesIngress(ingressContext, configContext);
                     }
                 }


### PR DESCRIPTION
* Does not handle an ip mapped to multiple endpoints
* It is inefficient to query all pods. Consider using _serviceToIngressNames and the service selector to limit the query to pods in a service with an ingress